### PR TITLE
fix(package): update vue-i18n to version 6.1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "vue": "~2.2.1",
     "vue-analytics": "~4.0.0",
     "vue-cookie": "~1.1.4",
-    "vue-i18n": "~5.0.3",
+    "vue-i18n": "~6.1.1",
     "vue-loader": "~11.3.4",
     "vue-meta": "~0.5.6",
     "vue-paginate": "~3.4.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4970,7 +4970,7 @@ readable-stream@1.0:
     isarray "0.0.1"
     string_decoder "~0.10.x"
 
-readable-stream@2.1.5:
+readable-stream@2.1.5, readable-stream@^2.0.1, readable-stream@^2.0.5:
   version "2.1.5"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.1.5.tgz#66fa8b720e1438b364681f2ad1a63c618448c9d0"
   dependencies:
@@ -4982,7 +4982,7 @@ readable-stream@2.1.5:
     string_decoder "~0.10.x"
     util-deprecate "~1.0.1"
 
-"readable-stream@^2.0.0 || ^1.1.13", readable-stream@^2.0.1, readable-stream@^2.0.2, readable-stream@^2.0.5, readable-stream@^2.1.0, readable-stream@^2.1.4, readable-stream@^2.2.2:
+"readable-stream@^2.0.0 || ^1.1.13", readable-stream@^2.0.2, readable-stream@^2.1.0, readable-stream@^2.1.4, readable-stream@^2.2.2:
   version "2.2.6"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.2.6.tgz#8b43aed76e71483938d12a8d46c6cf1a00b1f816"
   dependencies:
@@ -5916,9 +5916,9 @@ vue-hot-reload-api@^2.0.11:
   version "2.0.11"
   resolved "https://registry.yarnpkg.com/vue-hot-reload-api/-/vue-hot-reload-api-2.0.11.tgz#bf26374fb73366ce03f799e65ef5dfd0e28a1568"
 
-vue-i18n@~5.0.3:
-  version "5.0.3"
-  resolved "https://registry.yarnpkg.com/vue-i18n/-/vue-i18n-5.0.3.tgz#b6d96cc832604237e6139de471e0d4c820aedbed"
+vue-i18n@~6.1.1:
+  version "6.1.1"
+  resolved "https://registry.yarnpkg.com/vue-i18n/-/vue-i18n-6.1.1.tgz#6481915c59f16692b5f4bd8681afdce62492570c"
 
 vue-loader@~11.3.4:
   version "11.3.4"


### PR DESCRIPTION
Closes #152

Requires heavy refactoring in [`vue-i18n-6.0.0-migration`](https://github.com/wopian/hibari/tree/vue-i18n-6.0.0-migration) branch

https://greenkeeper.io/